### PR TITLE
🧹 Replace XMLHttpRequest with fetch API in script.js

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,32 +1,42 @@
 const form = document.querySelector("form"),
   statusTxt = form.querySelector(".button-area span");
+
 form.onsubmit = (e) => {
   e.preventDefault();
   statusTxt.style.color = "#0D6EFD";
   statusTxt.style.display = "block";
   statusTxt.innerText = "Sending your message...";
   form.classList.add("disabled");
-  let xhr = new XMLHttpRequest();
-  xhr.open("POST", "message.php", true);
-  xhr.onload = () => {
-    if (xhr.readyState == 4 && xhr.status == 200) {
-      let response = xhr.response;
-      if (
-        response.indexOf("required") != -1 ||
-        response.indexOf("valid") != -1 ||
-        response.indexOf("failed") != -1
-      ) {
-        statusTxt.style.color = "red";
-      } else {
-        form.reset();
-        setTimeout(() => {
-          statusTxt.style.display = "none";
-        }, 3000);
-      }
-      statusTxt.innerText = response;
-      form.classList.remove("disabled");
-    }
-  };
+
   let formData = new FormData(form);
-  xhr.send(formData);
+  fetch("message.php", {
+    method: "POST",
+    body: formData,
+  })
+    .then((response) => {
+      if (response.status === 200) {
+        return response.text();
+      }
+    })
+    .then((responseText) => {
+      if (responseText !== undefined) {
+        if (
+          responseText.indexOf("required") !== -1 ||
+          responseText.indexOf("valid") !== -1 ||
+          responseText.indexOf("failed") !== -1
+        ) {
+          statusTxt.style.color = "red";
+        } else {
+          form.reset();
+          setTimeout(() => {
+            statusTxt.style.display = "none";
+          }, 3000);
+        }
+        statusTxt.innerText = responseText;
+        form.classList.remove("disabled");
+      }
+    })
+    .catch((error) => {
+      console.error("Error:", error);
+    });
 };


### PR DESCRIPTION
🎯 **What:** Replaced the deprecated `XMLHttpRequest` with the modern `fetch` API in `script.js`.
💡 **Why:** The `fetch` API is the standard modern approach for making HTTP requests, providing a cleaner and more powerful way to handle asynchronous requests compared to `XMLHttpRequest`.
✅ **Verification:** Verified JavaScript syntax using `node -c script.js` and performed a manual code logic review to ensure parity with the original implementation.
✨ **Result:** Improved code maintainability and readability by using modern web standards.

---
*PR created automatically by Jules for task [14578443966914436562](https://jules.google.com/task/14578443966914436562) started by @mugovechakoma-droid*