### PR TITLE
🎨 Palette: Improve accessibility for floating WhatsApp button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-12 - Form Accessibility Pattern
+**Learning:** Base HTML templates in this project consistently rely on `placeholder` attributes for form fields, completely omitting accessible labels (`aria-label`), input names (`name` for form submission), and validation (`required`).
+**Action:** Always add explicit `aria-label`, `name`, and `required` attributes when working with forms to ensure screen reader compatibility and correct form submission.

--- a/index.html
+++ b/index.html
@@ -281,8 +281,8 @@
     </footer>
 
     <!-- Floating WhatsApp -->
-    <a href="https://wa.me/263772464452" class="whatsapp-float" target="_blank">
-        <i class="fab fa-whatsapp"></i>
+    <a href="https://wa.me/263772464452" class="whatsapp-float" target="_blank" aria-label="Contact us on WhatsApp">
+        <i class="fab fa-whatsapp" aria-hidden="true"></i>
     </a>
 
 </body>


### PR DESCRIPTION
💡 What: Added `aria-label="Contact us on WhatsApp"` to the floating WhatsApp anchor link and `aria-hidden="true"` to its nested decorative FontAwesome icon.
🎯 Why: Screen readers cannot discern the intent of an anchor link that contains only an icon without an accessible label, and reading the icon class itself can be confusing.
♿ Accessibility: Ensures correct and non-redundant announcements for users relying on assistive technologies to contact support.

---
*PR created automatically by Jules for task [10035932089001703321](https://jules.google.com/task/10035932089001703321) started by @mugovechakoma-droid*