### PR TITLE
🎨 Palette: Form Accessibility & WhatsApp Icon Improvement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-15 - [Form Accessibility Defaults]
+**Learning:** Found that base HTML templates frequently rely exclusively on `placeholder` attributes for form inputs, completely lacking `aria-label`, `name`, and `required` attributes which is a major accessibility block for screen readers.
+**Action:** When creating or modifying forms, always ensure inputs have proper `name` attributes for submission, `required` where applicable for validation, and `aria-label` (or associated `<label>`) for screen reader accessibility, even if a visual placeholder exists.

--- a/contact.html
+++ b/contact.html
@@ -72,13 +72,13 @@
                     <p style="color: var(--text-muted); margin-bottom: 40px;">Our tactical response team will review your inquiry and respond within 60 minutes.</p>
                     <form action="https://formsubmit.co/mugovechakoma@gmail.com" method="POST">
                         <div style="margin-bottom: 20px;">
-                            <input type="text" placeholder="Full Name" style="width: 100%; padding: 15px; border: 1px solid #ddd; border-radius: 10px; font-family: 'Inter', sans-serif;">
+                            <input type="text" name="name" aria-label="Full Name" required placeholder="Full Name" style="width: 100%; padding: 15px; border: 1px solid #ddd; border-radius: 10px; font-family: 'Inter', sans-serif;">
                         </div>
                         <div style="margin-bottom: 20px;">
-                            <input type="email" placeholder="Corporate Email" style="width: 100%; padding: 15px; border: 1px solid #ddd; border-radius: 10px; font-family: 'Inter', sans-serif;">
+                            <input type="email" name="email" aria-label="Corporate Email" required placeholder="Corporate Email" style="width: 100%; padding: 15px; border: 1px solid #ddd; border-radius: 10px; font-family: 'Inter', sans-serif;">
                         </div>
                         <div style="margin-bottom: 20px;">
-                            <textarea placeholder="How can we assist you?" rows="5" style="width: 100%; padding: 15px; border: 1px solid #ddd; border-radius: 10px; font-family: 'Inter', sans-serif;"></textarea>
+                            <textarea name="message" aria-label="Message" required placeholder="How can we assist you?" rows="5" style="width: 100%; padding: 15px; border: 1px solid #ddd; border-radius: 10px; font-family: 'Inter', sans-serif;"></textarea>
                         </div>
                         <button type="submit" class="btn-premium" style="width: 100%;">Initiate Consultation</button>
                     </form>

--- a/index.html
+++ b/index.html
@@ -244,9 +244,9 @@
                         <li><i class="fas fa-map-marker-alt" style="color: var(--accent-orange); margin-right: 10px;"></i> 115 Leopold Takawira St, Harare</li>
                     </ul>
                     <form action="#">
-                        <input type="text" placeholder="Your Name" style="width: 100%; padding: 15px; margin-bottom: 15px; border-radius: 10px; border: 1px solid #ddd;">
-                        <input type="email" placeholder="Your Email" style="width: 100%; padding: 15px; margin-bottom: 15px; border-radius: 10px; border: 1px solid #ddd;">
-                        <textarea placeholder="Tell us about your security needs" rows="4" style="width: 100%; padding: 15px; margin-bottom: 15px; border-radius: 10px; border: 1px solid #ddd;"></textarea>
+                        <input type="text" name="name" aria-label="Your Name" required placeholder="Your Name" style="width: 100%; padding: 15px; margin-bottom: 15px; border-radius: 10px; border: 1px solid #ddd;">
+                        <input type="email" name="email" aria-label="Your Email" required placeholder="Your Email" style="width: 100%; padding: 15px; margin-bottom: 15px; border-radius: 10px; border: 1px solid #ddd;">
+                        <textarea name="message" aria-label="Message" required placeholder="Tell us about your security needs" rows="4" style="width: 100%; padding: 15px; margin-bottom: 15px; border-radius: 10px; border: 1px solid #ddd;"></textarea>
                         <button type="submit" class="btn-premium" style="width: 100%;">Send Secure Message</button>
                     </form>
                 </div>
@@ -281,8 +281,8 @@
     </footer>
 
     <!-- Floating WhatsApp -->
-    <a href="https://wa.me/263772464452" class="whatsapp-float" target="_blank">
-        <i class="fab fa-whatsapp"></i>
+    <a href="https://wa.me/263772464452" class="whatsapp-float" target="_blank" rel="noopener noreferrer" aria-label="Chat with us on WhatsApp">
+        <i class="fab fa-whatsapp" aria-hidden="true"></i>
     </a>
 
 </body>


### PR DESCRIPTION
🎨 Palette: Form Accessibility Defaults & Icon Button A11y

**💡 What:** 
Added critical missing form accessibility attributes (`aria-label`, `name`, `required`) to the forms in both `index.html` and `contact.html`. Additionally, improved the floating WhatsApp icon link by adding a screen-reader-friendly `aria-label`, `rel="noopener noreferrer"` for security, and hiding the decorative FontAwesome icon from screen readers using `aria-hidden="true"`. Documented these critical learnings in `.Jules/palette.md`.

**🎯 Why:** 
Many base templates rely entirely on visual `placeholder` attributes. Screen readers cannot properly interpret the purpose of these form inputs without appropriate `aria-label` or `<label>` tags. Furthermore, without `name` attributes, the forms do not semantically submit data correctly. Similarly, the WhatsApp icon link was completely invisible to assistive technologies before adding the `aria-label`. 

**♿ Accessibility:**
- Added `aria-label` to form inputs.
- Added `name` and `required` to form inputs.
- Added `aria-label` to the WhatsApp button.
- Hides the purely decorative FontAwesome WhatsApp `<i>` tag with `aria-hidden="true"`.

---
*PR created automatically by Jules for task [6305844898355056737](https://jules.google.com/task/6305844898355056737) started by @mugovechakoma-droid*