### PR TITLE
🎨 Palette: Fix WhatsApp button accessibility & security

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-16 - Icon-Only Link Accessibility & Security
+**Learning:** Decorative font icons inside links or buttons often cause screen readers to read unintelligible classes unless explicitly hidden with `aria-hidden="true"`, and the parent link itself requires an `aria-label` for context. Furthermore, external links opening in new tabs (`target="_blank"`) must use `rel="noopener noreferrer"` to prevent reverse tabnabbing vulnerabilities.
+**Action:** When adding or encountering standalone icon links (like a floating WhatsApp button), always ensure the `<a>` has an explicit `aria-label`, the `<i>` has `aria-hidden="true"`, and external links include `rel="noopener noreferrer"`.

--- a/index.html
+++ b/index.html
@@ -281,8 +281,8 @@
     </footer>
 
     <!-- Floating WhatsApp -->
-    <a href="https://wa.me/263772464452" class="whatsapp-float" target="_blank">
-        <i class="fab fa-whatsapp"></i>
+    <a href="https://wa.me/263772464452" class="whatsapp-float" target="_blank" rel="noopener noreferrer" aria-label="Contact us on WhatsApp">
+        <i class="fab fa-whatsapp" aria-hidden="true"></i>
     </a>
 
 </body>


### PR DESCRIPTION
💡 **What:** Improved the accessibility and security of the floating WhatsApp button in `index.html`.
🎯 **Why:** Icon-only links without accessible names are confusing for screen reader users. Additionally, links opening in new tabs (`target="_blank"`) without `rel="noopener noreferrer"` expose the app to potential reverse tabnabbing attacks.
📸 **Before/After:** No visual changes were made.
♿ **Accessibility:** Added an `aria-label` to the link and `aria-hidden="true"` to the icon to correctly expose the interactive control to assistive technologies without redundant announcements.

---
*PR created automatically by Jules for task [17095336609704521745](https://jules.google.com/task/17095336609704521745) started by @mugovechakoma-droid*